### PR TITLE
Fix drop edge definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -162,7 +162,7 @@ declare abstract class AbstractGraph extends EventEmitter implements Iterable<Ad
   addUndirectedEdgeWithKey(edge: EdgeKey, source: NodeKey, target: NodeKey, attributes?: Attributes): string;
   mergeUndirectedEdgeWithKey(edge: EdgeKey, source: NodeKey, target: NodeKey, attributes?: Attributes): string;
   dropNode(node: NodeKey): void;
-  dropEdge(edge: EdgeKey): void;
+  dropEdge(source: NodeKey, target: NodeKey): void;
   clear(): void;
   clearEdges(): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -162,6 +162,7 @@ declare abstract class AbstractGraph extends EventEmitter implements Iterable<Ad
   addUndirectedEdgeWithKey(edge: EdgeKey, source: NodeKey, target: NodeKey, attributes?: Attributes): string;
   mergeUndirectedEdgeWithKey(edge: EdgeKey, source: NodeKey, target: NodeKey, attributes?: Attributes): string;
   dropNode(node: NodeKey): void;
+  dropEdge(edge: EdgeKey): void;
   dropEdge(source: NodeKey, target: NodeKey): void;
   clear(): void;
   clearEdges(): void;


### PR DESCRIPTION
Drop edge should accept two parameter of the nodes of the edge as you cant relay that one will hold the edge key for each edge in the graph